### PR TITLE
small syntax improvements, tidying up for tf15.1

### DIFF
--- a/resources.tf
+++ b/resources.tf
@@ -1,6 +1,6 @@
 resource "docker_image" "image" {
   for_each = try(var.stack, {})
-  name     = "${tostring(try(each.value.Image, each.key))}:${tostring(try(each.value.tags, "latest"))}"
+  name     = join(":", [try(each.value.Image, each.key), try(each.value.tags, "latest")])
 }
 
 resource "docker_container" "container" {


### PR DESCRIPTION
more changes coming, tf15 is getting an error message below:

`Attribute supports 1 item maximum, config has 2 declared`

I am going to meticulously go through the different modules, tidy things up, and see if I can find the breaking point and resolve it. Suspect it relates to iterating in a resource block but not yet sure; there are also definitely at least a few use-cases worth updating here to match more modern syntax